### PR TITLE
Use yaml.safe_load

### DIFF
--- a/safe_grid_agents/parsing/parse.py
+++ b/safe_grid_agents/parsing/parse.py
@@ -80,11 +80,11 @@ def handle_parser_args(parsers, name, configs) -> None:
 
 # Import yaml configs
 with open(core_config) as core_yaml:
-    core_parser_configs = yaml.load(core_yaml)
+    core_parser_configs = yaml.safe_load(core_yaml)
 with open(env_config, "r") as env_yaml:
-    env_parser_configs = yaml.load(env_yaml)
+    env_parser_configs = yaml.safe_load(env_yaml)
 with open(agent_config, "r") as agent_yaml:
-    agent_parser_configs = yaml.load(agent_yaml)
+    agent_parser_configs = yaml.safe_load(agent_yaml)
 stashed_agent_parser_configs = deepcopy(agent_parser_configs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     ),
     install_requires=[
         "safe-grid-gym @ git+https://github.com/david-lindner/safe-grid-gym.git",
-        "pyyaml",
+        "pyyaml>=5.1",
         "moviepy",
         "tensorboardX<=1.5",
         "ray",


### PR DESCRIPTION
Avoid needless security issue. Still loads our subset of YAML fine, since we're
not using advanced functionality. It silences a few warnings.